### PR TITLE
Fix redirect after inventory submission

### DIFF
--- a/includes/class-evy-fifo-inventory-manager.php
+++ b/includes/class-evy-fifo-inventory-manager.php
@@ -28,7 +28,7 @@ class Evy_FIFO_Inventory_Manager {
             } else {
                 error_log( 'Evy Cost FIFO: Nonce verification failed.' );
             }
-            wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-receipt' ) );
+            wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-in' ) );
             exit;
         }
 
@@ -102,7 +102,7 @@ class Evy_FIFO_Inventory_Manager {
                 }
             }
         }
-        wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-receipt' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-in' ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- fix redirect destination in handle_inventory_in_submission to go back to Inventory In page

## Testing
- `php -l includes/class-evy-fifo-inventory-manager.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844257fcca48332a060e379292501df