### PR TITLE
Fix form action and nonce handling

### DIFF
--- a/admin/inventory-in.php
+++ b/admin/inventory-in.php
@@ -31,8 +31,8 @@
     <p><?php esc_html_e( 'Use this page to record inventory receipts using the FIFO principle.', 'evy-cost-fifo' ); ?></p>
 
     <form method="post" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-        <?php wp_nonce_field( 'evy_fifo_inventory_in_action', '_wpnonce' ); ?>
-        <input type="hidden" name="action" value="evy_fifo_save_inventory_in">
+        <?php wp_nonce_field( 'evy_fifo_add_inventory_receipt', 'evy_fifo_add_inventory_receipt' ); ?>
+        <input type="hidden" name="action" value="evy_fifo_add_inventory_receipt">
 
         <table class="form-table">
             <tbody>

--- a/includes/class-evy-fifo-inventory-manager.php
+++ b/includes/class-evy-fifo-inventory-manager.php
@@ -21,18 +21,17 @@ class Evy_FIFO_Inventory_Manager {
             wp_die( __( 'You do not have sufficient permissions to access this page.', 'evy-cost-fifo' ) );
         }
 
-        if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'evy_fifo_add_inventory_receipt' ) ) {
+        if ( ! isset( $_POST['evy_fifo_add_inventory_receipt'] ) || ! wp_verify_nonce( $_POST['evy_fifo_add_inventory_receipt'], 'evy_fifo_add_inventory_receipt' ) ) {
             // nonce ไม่ถูกต้อง
             if ( function_exists( 'wc_add_notice' ) ) {
                 wc_add_notice( __( 'Security check failed. Please try again.', 'evy-cost-fifo' ), 'error' );
             } else {
                 error_log( 'Evy Cost FIFO: Nonce verification failed.' );
             }
-            wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-receipt' ) );
+            wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-in' ) );
             exit;
         }
 
-        if ( isset( $_POST['evy_fifo_add_inventory_receipt'] ) ) {
             $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
             $quantity = isset( $_POST['quantity'] ) ? floatval( $_POST['quantity'] ) : 0;
             $unit_cost = isset( $_POST['unit_cost'] ) ? floatval( $_POST['unit_cost'] ) : 0;
@@ -101,8 +100,7 @@ class Evy_FIFO_Inventory_Manager {
                     error_log( 'Evy Cost FIFO: Missing required fields for inventory receipt.' );
                 }
             }
-        }
-        wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-receipt' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=evy-fifo-inventory-in' ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- ensure inventory in form submits to `evy_fifo_add_inventory_receipt`
- verify nonce using matching key
- redirect to the correct submenu

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844257a59a8833281f78da33129e0ba