### PR TITLE
Add localization loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ evy-cost-fifo/
 5.  Visit the **Evy Cost FIFO Settings** page to configure your **Google Spreadsheet ID** and place the `credentials.json` file (obtained from your Google Cloud Project Service Account) directly into the main plugin folder (`evy-cost-fifo/`).
 6.  Begin by entering your Inventory In data and let the system integrate with WooCommerce order statuses.
 
+
+### Translations
+
+Place translation files (e.g., .mo and .po) inside the `languages/` directory in the plugin folder.
+
 ### ⚠️ Important Notes for Developers
 
 * **Non-intrusive to WooCommerce Core:** This plugin is designed to extend costing capabilities without interfering with WooCommerce's fundamental stock management or the operational logic of other Extensions like Bookings or Subscriptions. Actual stock updates remain handled by WooCommerce.

--- a/evy-cost-fifo.php
+++ b/evy-cost-fifo.php
@@ -31,6 +31,11 @@ if ( ! defined( 'EVY_FIFO_PLUGIN_BASENAME' ) ) {
     define( 'EVY_FIFO_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 }
 
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'evy-cost-fifo', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+} );
+
+
 
 // --- ตรวจสอบว่า WooCommerce ติดตั้งและเปิดใช้งานอยู่หรือไม่ ---
 // เพื่อให้แน่ใจว่าฟังก์ชัน WooCommerce (wc_get_product, wc_add_notice) พร้อมใช้งาน


### PR DESCRIPTION
## Summary
- load plugin textdomain on `plugins_loaded`
- mention `languages/` directory in README
- add empty `languages` folder

## Testing
- `php -l evy-cost-fifo.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844335e3db883328665494aefdc0e72