### PR TITLE
Refactor Inventory In form

### DIFF
--- a/admin/inventory-in.php
+++ b/admin/inventory-in.php
@@ -83,27 +83,8 @@
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="shipping_cost_per_unit"><?php esc_html_e( 'Shipping Cost per Unit:', 'evy-cost-fifo' ); ?></label></th>
-                    <td>
-                        <input type="number" name="shipping_cost_per_unit" id="shipping_cost_per_unit" class="regular-text" step="0.01" min="0" value="0">
-                        <span class="description"><?php esc_html_e( 'Enter shipping cost with up to 2 decimal places.', 'evy-cost-fifo' ); ?></span>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="is_paid"><?php esc_html_e( 'Paid:', 'evy-cost-fifo' ); ?></label></th>
-                    <td><input type="checkbox" name="is_paid" id="is_paid" value="1"> <span class="description"><?php esc_html_e( 'Check if the payment for this item has been made.', 'evy-cost-fifo' ); ?></span></td>
-                </tr>
-                <tr class="payment-fields" style="display: none;">
-                    <th scope="row"><label for="payment_date"><?php esc_html_e( 'Payment Date:', 'evy-cost-fifo' ); ?></label></th>
-                    <td><input type="date" name="payment_date" id="payment_date" class="regular-text" value="<?php echo date('Y-m-d'); ?>"></td>
-                </tr>
-                <tr class="payment-fields" style="display: none;">
-                    <th scope="row"><label for="payment_ref"><?php esc_html_e( 'Payment Reference:', 'evy-cost-fifo' ); ?></label></th>
-                    <td><input type="text" name="payment_ref" id="payment_ref" class="regular-text"></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="notes"><?php esc_html_e( 'Notes:', 'evy-cost-fifo' ); ?></label></th>
-                    <td><textarea name="notes" id="notes" class="large-text code" rows="5"></textarea></td>
+                    <th scope="row"><label for="notes"><?php esc_html_e( 'Reference Document:', 'evy-cost-fifo' ); ?></label></th>
+                    <td><input type="text" name="notes" id="notes" class="regular-text"></td>
                 </tr>
             </tbody>
         </table>
@@ -147,27 +128,9 @@
             console.warn('Select2 is not loaded. Product search will not work.');
         }
 
-        // Toggle payment fields based on 'is_paid' checkbox
-        $('#is_paid').on('change', function() {
-            if ($(this).is(':checked')) {
-                $('.payment-fields').show();
-                $('#payment_date').prop('required', true);
-            } else {
-                $('.payment-fields').hide();
-                $('#payment_date').prop('required', false);
-                $('#payment_date').val('');
-                $('#payment_ref').val('');
-            }
-        }).trigger('change');
-
         // Optional: Auto-fill purchase_date to today
         if (!$('#purchase_date').val()) {
             $('#purchase_date').val('<?php echo date('Y-m-d'); ?>');
-        }
-        // Optional: Auto-fill payment_date to today if is_paid is checked
-        $('#is_paid').trigger('change');
-        if ($('#is_paid').is(':checked') && !$('#payment_date').val()) {
-            $('#payment_date').val('<?php echo date('Y-m-d'); ?>');
         }
     });
 </script>

--- a/includes/class-evy-fifo-database-manager.php
+++ b/includes/class-evy-fifo-database-manager.php
@@ -42,7 +42,6 @@ class Evy_FIFO_Database_Manager {
             quantity DECIMAL(10,4) NOT NULL,
             remaining_quantity DECIMAL(10,4) NOT NULL,
             unit_cost DECIMAL(10,4) NOT NULL,
-            shipping_cost_per_unit DECIMAL(10,4) NOT NULL DEFAULT '0.0000',
             cost_per_unit_with_shipping DECIMAL(10,4) NOT NULL,
             total_cost DECIMAL(10,4) NOT NULL,
             supplier_name VARCHAR(255) NULL,
@@ -120,16 +119,12 @@ class Evy_FIFO_Database_Manager {
             'quantity'          => isset( $data['quantity'] ) ? $data['quantity'] : 0,
             'remaining_quantity' => isset( $data['remaining_quantity'] ) ? $data['remaining_quantity'] : 0,
             'unit_cost'         => isset( $data['unit_cost'] ) ? $data['unit_cost'] : 0,
-            'shipping_cost_per_unit' => isset( $data['shipping_cost_per_unit'] ) ? $data['shipping_cost_per_unit'] : 0,
             'cost_per_unit_with_shipping' => isset( $data['cost_per_unit_with_shipping'] ) ? $data['cost_per_unit_with_shipping'] : 0,
             'total_cost'        => isset( $data['total_cost'] ) ? $data['total_cost'] : 0,
             'supplier_name'     => isset( $data['supplier_name'] ) ? $data['supplier_name'] : '',
             'purchase_source'   => isset( $data['purchase_source'] ) ? $data['purchase_source'] : 'local',
             'credit_term_days'  => isset( $data['credit_term_days'] ) ? $data['credit_term_days'] : 0,
             'due_date'          => isset( $data['due_date'] ) ? $data['due_date'] : null,
-            'is_paid'           => isset( $data['is_paid'] ) ? $data['is_paid'] : 0,
-            'payment_date'      => isset( $data['payment_date'] ) ? $data['payment_date'] : null,
-            'payment_ref'       => isset( $data['payment_ref'] ) ? $data['payment_ref'] : '',
             'notes'             => isset( $data['notes'] ) ? $data['notes'] : '',
             'created_at'        => current_time( 'mysql' ),
             'updated_at'        => null,
@@ -142,16 +137,12 @@ class Evy_FIFO_Database_Manager {
             '%f', // quantity
             '%f', // remaining_quantity
             '%f', // unit_cost
-            '%f', // shipping_cost_per_unit
             '%f', // cost_per_unit_with_shipping
             '%f', // total_cost
             '%s', // supplier_name
             '%s', // purchase_source
             '%d', // credit_term_days
             '%s', // due_date
-            '%d', // is_paid
-            '%s', // payment_date
-            '%s', // payment_ref
             '%s', // notes
             '%s', // created_at
             '%s', // updated_at
@@ -170,9 +161,6 @@ class Evy_FIFO_Database_Manager {
                 'supplier_name'   => $insert_data['supplier_name'],
                 'amount'          => $insert_data['total_cost'],
                 'due_date'        => $insert_data['due_date'],
-                'is_paid'         => $insert_data['is_paid'],
-                'payment_date'    => $insert_data['payment_date'],
-                'payment_ref'     => $insert_data['payment_ref'],
                 'notes'           => $insert_data['notes'],
                 'created_at'      => current_time( 'mysql' ),
             );
@@ -182,9 +170,6 @@ class Evy_FIFO_Database_Manager {
                 '%s', // supplier_name
                 '%f', // amount
                 '%s', // due_date
-                '%d', // is_paid
-                '%s', // payment_date
-                '%s', // payment_ref
                 '%s', // notes
                 '%s', // created_at
             );


### PR DESCRIPTION
## Summary
- simplify Inventory In form UI and remove payment-related inputs
- store only reference document text
- drop shipping and payment fields from inventory and database logic

## Testing
- `php -l admin/inventory-in.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684450beded483328a4ba4bf6269ad00